### PR TITLE
Improve launcher robustness and update install guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AstrBotLauncher
 
-https://github.com/Soulter/AstrBot  的适用于 Windows 的启动器。
+适用于 Windows 的 [AstrBot](https://astrbot.app) 启动器。
 
 ## 推荐安装方式
 
@@ -13,6 +13,9 @@ https://github.com/Soulter/AstrBot  的适用于 Windows 的启动器。
 
 ## 使用方式
 
+请参考 [文档](https://docs.astrbot.app/deploy/astrbot/windows.html)
+
+下面是简略版教程：
 
 > [!WARNING]
 > 如果启动后直接闪退，请尝试运行 `launcher_astrbot_en.bat`。
@@ -20,7 +23,7 @@ https://github.com/Soulter/AstrBot  的适用于 Windows 的启动器。
 1. 打开 PowerShell，尝试输入 `python`，版本应该大于 3.10。关闭窗口。
 > 1. 如果你曾更换过启动器命令，或者你确信安装了 Python 但是输入指令后显示 `无法将...识别为` 的消息，可以尝试 `python3`，或者重启 PowerShell 窗口。如果 `python3` 成功了，请将 `launcher_astrbot_en.bat` 中的 `set PYTHON_CMD=` 后的内容改成 `python3`。
 
-2. 前往 [release](https://github.com/Soulter/AstrBotLauncher/releases) 下载第一个 Asset。
+2. 前往 [release](https://github.com/AstrBotDevs/AstrBotLauncher/releases) 下载第一个 Asset。
 3. 下载压缩包后，将压缩包内的文件夹解压到磁盘，然后直接双击解压好的文件夹内 `launcher_astrbot_en.bat` 即可。
 
 > [!WARNING]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ https://github.com/Soulter/AstrBot  的适用于 Windows 的启动器。
 
 ## 前置条件
 
-1. 需要 Windows 上安装有 Powershell。（此工具是 Windows 自带的，除非你手动卸载过或者下载的是精简版 Windows）
+1. 需要 Windows 上安装有 PowerShell。（此工具是 Windows 自带的，除非你手动卸载过或者下载的是精简版 Windows）
 2. 电脑上安装有 Python，且版本 >= 3.10
 
 ## 使用方式
@@ -17,8 +17,8 @@ https://github.com/Soulter/AstrBot  的适用于 Windows 的启动器。
 > [!WARNING]
 > 如果启动后直接闪退，请尝试运行 `launcher_astrbot_en.bat`。
 
-1. 打开 Powershell，尝试输入 `python`，版本应该大于 3.10。关闭窗口。
-> 1. 如果你曾更换过启动器命令，或者你确信安装了 Python 但是输入指令后显示 `无法将...识别为` 的消息，可以尝试 `python3`，或者重启 Powershell 窗口。如果 `python3` 成功了，请将 `launcher_astrbot_en.bat` 中的 `set PYTHON_CMD=` 后的内容改成 `python3`。
+1. 打开 PowerShell，尝试输入 `python`，版本应该大于 3.10。关闭窗口。
+> 1. 如果你曾更换过启动器命令，或者你确信安装了 Python 但是输入指令后显示 `无法将...识别为` 的消息，可以尝试 `python3`，或者重启 PowerShell 窗口。如果 `python3` 成功了，请将 `launcher_astrbot_en.bat` 中的 `set PYTHON_CMD=` 后的内容改成 `python3`。
 
 2. 前往 [release](https://github.com/Soulter/AstrBotLauncher/releases) 下载第一个 Asset。
 3. 下载压缩包后，将压缩包内的文件夹解压到磁盘，然后直接双击解压好的文件夹内 `launcher_astrbot_en.bat` 即可。

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 https://github.com/Soulter/AstrBot  的适用于 Windows 的启动器。
 
+## 推荐安装方式
+
+优先前往 [AstrBot 官方 Release](https://github.com/AstrBotDevs/AstrBot/releases)，下载与你当前操作系统对应的安装包。
+
 ## 前置条件
 
 1. 需要 Windows 上安装有 Powershell。（此工具是 Windows 自带的，除非你手动卸载过或者下载的是精简版 Windows）
@@ -14,11 +18,10 @@ https://github.com/Soulter/AstrBot  的适用于 Windows 的启动器。
 > 如果启动后直接闪退，请尝试运行 `launcher_astrbot_en.bat`。
 
 1. 打开 Powershell，尝试输入 `python`，版本应该大于 3.10。关闭窗口。
-> 1. 如果你曾更换过启动器命令，或者你确信安装了 Python 但是输入指令后显示 `无法将...识别为` 的消息，可以尝试 `python3`，或者重启 Powershell 窗口。如果 `Python3` 成功了，请将下一个步骤中下载好的内容中的 `launcher_astrbot.bat` 中的 `set PYTHON_CMD=` 后的内容改成 `python3`
+> 1. 如果你曾更换过启动器命令，或者你确信安装了 Python 但是输入指令后显示 `无法将...识别为` 的消息，可以尝试 `python3`，或者重启 Powershell 窗口。如果 `python3` 成功了，请将 `launcher_astrbot_en.bat` 中的 `set PYTHON_CMD=` 后的内容改成 `python3`。
 
 2. 前往 [release](https://github.com/Soulter/AstrBotLauncher/releases) 下载第一个 Asset。
-3. 下载压缩包后，将压缩包内的文件夹解压到磁盘，然后直接双击解压好的文件夹内 `launcher_astrbot.bat` 即可。
+3. 下载压缩包后，将压缩包内的文件夹解压到磁盘，然后直接双击解压好的文件夹内 `launcher_astrbot_en.bat` 即可。
 
 > [!WARNING]
 > 如果启动后直接闪退，请尝试运行 `launcher_astrbot_en.bat`。
-

--- a/launcher_astrbot_en.bat
+++ b/launcher_astrbot_en.bat
@@ -17,6 +17,7 @@ set FALLBACK_MIRROR_URL=https://pypi.org/simple
 set ASTRBOT_EXIT_CODE=0
 set DOWNLOAD_MAX_RETRIES=3
 set DOWNLOAD_RETRY_DELAY_SEC=3
+set PROJECT_DIR_CHANGED=0
 
 :: Check if Python is installed
 %PYTHON_CMD% --version >nul 2>&1
@@ -169,13 +170,15 @@ exit /b 0
 :: Change to AstrBot or QQChannelChatGPT directory
 if exist AstrBot (
     cd AstrBot
+    set PROJECT_DIR_CHANGED=1
 ) else (
     if exist QQChannelChatGPT (
         cd QQChannelChatGPT
+        set PROJECT_DIR_CHANGED=1
     ) else (
         echo [ERROR] Neither AstrBot nor QQChannelChatGPT folder exists.
         set ASTRBOT_EXIT_CODE=1
-        goto end
+        goto cleanup
     )
 )
 
@@ -186,7 +189,7 @@ if not exist venv (
     if errorlevel 1 (
         echo [ERROR] Failed to create virtual environment.
         set ASTRBOT_EXIT_CODE=1
-        goto end
+        goto cleanup
     )
 )
 
@@ -195,7 +198,7 @@ call venv\Scripts\activate.bat
 if errorlevel 1 (
     echo [ERROR] Failed to activate virtual environment.
     set ASTRBOT_EXIT_CODE=1
-    goto end
+    goto cleanup
 )
 
 :: Check for dependency updates
@@ -207,7 +210,7 @@ if errorlevel 1 (
     if errorlevel 1 (
         echo [ERROR] Failed to upgrade pip.
         set ASTRBOT_EXIT_CODE=1
-        goto end
+        goto cleanup
     )
 )
 
@@ -219,7 +222,7 @@ if errorlevel 1 (
     if errorlevel 1 (
         echo [ERROR] Failed to install uv.
         set ASTRBOT_EXIT_CODE=1
-        goto end
+        goto cleanup
     )
 )
 
@@ -231,7 +234,7 @@ if errorlevel 1 (
     if errorlevel 1 (
         echo [ERROR] Failed to install dependencies from requirements.txt.
         set ASTRBOT_EXIT_CODE=1
-        goto end
+        goto cleanup
     )
 )
 
@@ -247,7 +250,13 @@ if %ASTRBOT_EXIT_CODE% neq 0 (
 :: Deactivate the virtual environment
 call venv\Scripts\deactivate.bat
 
-cd ..
+goto cleanup
+
+:cleanup
+if "%PROJECT_DIR_CHANGED%"=="1" (
+    cd ..
+    set PROJECT_DIR_CHANGED=0
+)
 
 :end
 if not "%ASTRBOT_NO_PAUSE%"=="1" (

--- a/launcher_astrbot_en.bat
+++ b/launcher_astrbot_en.bat
@@ -146,12 +146,14 @@ exit /b 0
 :: Change to AstrBot or QQChannelChatGPT directory
 if exist AstrBot (
     cd AstrBot
-) else if exist QQChannelChatGPT (
-    cd QQChannelChatGPT
 ) else (
-    echo [ERROR] Neither AstrBot nor QQChannelChatGPT folder exists.
-    set ASTRBOT_EXIT_CODE=1
-    goto end
+    if exist QQChannelChatGPT (
+        cd QQChannelChatGPT
+    ) else (
+        echo [ERROR] Neither AstrBot nor QQChannelChatGPT folder exists.
+        set ASTRBOT_EXIT_CODE=1
+        goto end
+    )
 )
 
 :: Set up a virtual environment

--- a/launcher_astrbot_en.bat
+++ b/launcher_astrbot_en.bat
@@ -91,11 +91,12 @@ if "%download_url%"=="" (
     exit /b 1
 )
 
-echo [INFO] Downloading the latest version of AstrBot from %download_url%...
+set "ASTRBOT_DOWNLOAD_URL=%download_url%"
+echo [INFO] Downloading the latest version of AstrBot...
 
 :download
 :: Download the latest zipball version
-powershell -NoProfile -Command "$ErrorActionPreference = 'Stop'; Invoke-WebRequest -Uri '%download_url%' -OutFile 'latest.zip'"
+powershell -NoProfile -Command "$ErrorActionPreference = 'Stop'; Invoke-WebRequest -Uri $env:ASTRBOT_DOWNLOAD_URL -OutFile 'latest.zip'"
 
 if errorlevel 1 (
     echo [ERROR] Failed to download the latest version file. Please check your network and try again.
@@ -224,5 +225,7 @@ call venv\Scripts\deactivate.bat
 cd ..
 
 :end
-pause
+if not "%ASTRBOT_NO_PAUSE%"=="1" (
+    if %ASTRBOT_EXIT_CODE% neq 0 pause
+)
 endlocal & exit /b %ASTRBOT_EXIT_CODE%


### PR DESCRIPTION
## 背景
  启动器在首次下载、依赖安装和网络不稳定场景下容错不足，用户容易遇到“启动失败但原因不明确”的问题；
  README 也存在脚本文件名不一致和安装指引不够明确的问题。

  ## 变更内容
  1. 增强 `launcher_astrbot_en.bat` 稳定性
  - 使用 `Invoke-RestMethod` 获取最新 release，并校验 `zipball_url`。
  - 下载链接为空/下载失败/解压失败时立即中断并输出明确错误。
  - 将下载逻辑改为子程序返回码模式（`exit /b` + `errorlevel`），避免流程误跳转。
  - 目录切换增加显式判断（`AstrBot` / `QQChannelChatGPT` 不存在时给出错误）。
  - `venv` 创建与激活失败时中断。
  - `pip` / `uv` / `requirements` 安装支持镜像失败后自动回退官方 PyPI。
  - `main.py` 异常退出时提示错误。

  2. 更新 README
  - 新增“推荐安装方式”：优先从 `https://github.com/AstrBotDevs/AstrBot/releases` 下载对应操作系统安装
  包。
  - 修正文档中的脚本名，统一为 `launcher_astrbot_en.bat`。

  ## 影响范围
  - 仅影响 Windows 启动脚本和文档，不改动 AstrBot 业务代码。
  - 对已有用户兼容，主要提升失败场景可诊断性和安装成功率。

  ## 验证
  - 已在 Windows 环境完成一次运行验证。

## Sourcery 总结

提升 Windows 启动脚本在环境校验、发布版本下载、依赖安装以及进程退出状态上报方面的健壮性，并在 README 中澄清推荐的安装路径。

新功能：
- 为 pip、uv 和 requirements 安装失败的情况添加自动回退机制：从镜像 PyPI 索引自动回退到官方 PyPI 索引。

错误修复：
- 确保在获取 GitHub Release 时会校验 API 响应和下载 URL，并在 API、下载或解压出错时快速失败并给出清晰的错误信息。
- 通过使用子例程返回码和显式的 errorlevel 检查，防止在下载失败后启动器继续执行。
- 在设置前检测 AstrBot 或 QQChannelChatGPT 目录是否缺失，如缺失则中止并给出明确的错误提示。
- 在虚拟环境创建、激活或依赖安装失败时停止执行，而不是静默继续。
- 在主 AstrBot 进程返回非零退出码时进行报告，而不是静默退出。

增强：
- 通过在启动器中使用带 no-profile 的 PowerShell `Invoke-RestMethod` 以及更严格的网络错误处理，加强 PowerShell 的使用安全性。
- 改进虚拟环境设置和依赖安装步骤中的日志记录与诊断信息。
- 跟踪并向调用方传递统一的启动器退出码，以便于更清晰的外部错误处理。

文档：
- 在 README 中记录通过官方 AstrBot Release 进行安装的推荐方式，并更正启动脚本名称和 Python 命令的使用说明。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 总结

改进 Windows 启动脚本在环境检查、版本发布下载、依赖安装和退出码方面的健壮性，并在 README 中澄清推荐的安装步骤。

新特性：
- 为 pip、uv 和 requirements 安装失败时，新增从镜像 PyPI 索引自动回退到官方 PyPI 索引的机制。

缺陷修复：
- 当缺少 Python 或 Python 版本低于要求时停止启动器运行，并返回明确的非零退出码。
- 当 GitHub 发布版本元数据获取、下载链接获取、文件下载或压缩包解压失败时快速失败，并给出清晰的错误信息。
- 通过显式检查 AstrBot 或 QQChannelChatGPT 目录是否存在，防止在这些目录缺失时继续执行安装。
- 在虚拟环境创建或激活失败，以及依赖安装出错时中止执行，而不是静默继续。
- 当主 AstrBot 进程返回非零退出码时进行上报，而不是静默退出。

增强改进：
- 通过使用无配置文件模式（no-profile）、`Invoke-RestMethod`，以及对网络和压缩包操作采用更严格的错误处理方式，加强启动器中对 PowerShell 的使用安全性。
- 改进虚拟环境和依赖安装过程的日志记录，并统一跟踪和返回单一的启动器退出码。
- 在保持错误场景下可配置的暂停行为的同时，避免在运行成功时暂停。

文档：
- 在 README 中记录通过官方 AstrBot Releases 的推荐安装路径，并修正启动脚本名称以及 PowerShell/Python 的使用说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

增强 Windows 启动脚本在环境检查、发布版本下载、依赖安装以及退出码报告方面的健壮性，并更新 README，使其中的安装说明和脚本名称更加清晰、且与当前情况保持一致。

New Features:
- 当 `pip`、`uv` 或安装 `requirements` 失败时，自动从镜像 PyPI 索引回退到官方 PyPI 索引。

Bug Fixes:
- 当未安装 Python 或 Python 版本低于要求时，以清晰的非零退出码停止启动器。
- 确保 GitHub 发布元数据获取、下载 URL 获取、文件下载以及归档解压失败时，会立即终止并给出清晰的错误信息，而不是继续执行。
- 当缺少 `AstrBot` 或 `QQChannelChatGPT` 目录，或虚拟环境创建、激活、依赖安装失败时，中止安装流程并给出明确错误。
- 当主 `AstrBot` 进程异常退出时，报告并向外传播非零退出码，而不是静默地视为成功。

Enhancements:
- 通过使用无配置文件模式（no-profile）、`Invoke-RestMethod`、更严格的错误处理以及发布版本下载重试逻辑，改进启动器中的 PowerShell 使用。
- 优化虚拟环境和依赖安装的日志与诊断信息，并在外部错误处理时一致地向外传播单一的启动器退出码。
- 在运行成功时避免暂停，同时保留在出错时可配置的暂停行为。

Documentation:
- 在 README 中记录通过官方 AstrBot 发布版本进行安装的推荐路径，并更正 Windows 启动脚本名称以及有关 Python/PowerShell 使用的说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen the Windows launcher script’s robustness around environment checks, release download, dependency installation, and exit-code reporting, and refresh the README with clearer, up-to-date installation instructions and script names.

New Features:
- Add automatic fallback from the mirror PyPI index to the official PyPI index when pip, uv, or requirements installation fails.

Bug Fixes:
- Stop the launcher with a clear non-zero exit code when Python is missing or below the required version.
- Ensure GitHub release metadata, download URL retrieval, file download, and archive extraction failures cause immediate, clearly messaged termination instead of continuing execution.
- Abort setup with explicit errors when the AstrBot or QQChannelChatGPT directory is missing, or when virtual environment creation, activation, or dependency installation fails.
- Report and propagate a non-zero exit code when the main AstrBot process exits abnormally instead of silently succeeding.

Enhancements:
- Improve PowerShell usage in the launcher by using no-profile mode, Invoke-RestMethod, stricter error handling, and retry logic for release downloads.
- Refine virtual environment and dependency installation logging and diagnostics, and consistently propagate a single launcher exit code for clearer external error handling.
- Avoid pausing on successful runs while retaining configurable pause behavior on errors.

Documentation:
- Document the recommended installation path via official AstrBot releases and correct the Windows launcher script name and Python/PowerShell usage notes in the README.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

增强 Windows 启动脚本在环境检查、发布版本下载、依赖安装以及退出码报告方面的健壮性，并更新 README，使其中的安装说明和脚本名称更加清晰、且与当前情况保持一致。

New Features:
- 当 `pip`、`uv` 或安装 `requirements` 失败时，自动从镜像 PyPI 索引回退到官方 PyPI 索引。

Bug Fixes:
- 当未安装 Python 或 Python 版本低于要求时，以清晰的非零退出码停止启动器。
- 确保 GitHub 发布元数据获取、下载 URL 获取、文件下载以及归档解压失败时，会立即终止并给出清晰的错误信息，而不是继续执行。
- 当缺少 `AstrBot` 或 `QQChannelChatGPT` 目录，或虚拟环境创建、激活、依赖安装失败时，中止安装流程并给出明确错误。
- 当主 `AstrBot` 进程异常退出时，报告并向外传播非零退出码，而不是静默地视为成功。

Enhancements:
- 通过使用无配置文件模式（no-profile）、`Invoke-RestMethod`、更严格的错误处理以及发布版本下载重试逻辑，改进启动器中的 PowerShell 使用。
- 优化虚拟环境和依赖安装的日志与诊断信息，并在外部错误处理时一致地向外传播单一的启动器退出码。
- 在运行成功时避免暂停，同时保留在出错时可配置的暂停行为。

Documentation:
- 在 README 中记录通过官方 AstrBot 发布版本进行安装的推荐路径，并更正 Windows 启动脚本名称以及有关 Python/PowerShell 使用的说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen the Windows launcher script’s robustness around environment checks, release download, dependency installation, and exit-code reporting, and refresh the README with clearer, up-to-date installation instructions and script names.

New Features:
- Add automatic fallback from the mirror PyPI index to the official PyPI index when pip, uv, or requirements installation fails.

Bug Fixes:
- Stop the launcher with a clear non-zero exit code when Python is missing or below the required version.
- Ensure GitHub release metadata, download URL retrieval, file download, and archive extraction failures cause immediate, clearly messaged termination instead of continuing execution.
- Abort setup with explicit errors when the AstrBot or QQChannelChatGPT directory is missing, or when virtual environment creation, activation, or dependency installation fails.
- Report and propagate a non-zero exit code when the main AstrBot process exits abnormally instead of silently succeeding.

Enhancements:
- Improve PowerShell usage in the launcher by using no-profile mode, Invoke-RestMethod, stricter error handling, and retry logic for release downloads.
- Refine virtual environment and dependency installation logging and diagnostics, and consistently propagate a single launcher exit code for clearer external error handling.
- Avoid pausing on successful runs while retaining configurable pause behavior on errors.

Documentation:
- Document the recommended installation path via official AstrBot releases and correct the Windows launcher script name and Python/PowerShell usage notes in the README.

</details>

</details>

</details>

</details>

**新功能：**
- 为 `pip`、`uv` 和基于 `requirements` 的安装失败，新增从镜像 PyPI 源自动回退到官方 PyPI 源的机制。

**缺陷修复：**
- 确保 GitHub Release 下载步骤会校验 API 响应和下载 URL，并在 API、下载或解压出现问题时快速失败并给出清晰的错误信息。
- 通过使用子例程返回码并在尝试下载最新版本后进行显式检查，防止错误地继续执行后续流程。
- 在安装前增加对 AstrBot 或 QQChannelChatGPT 目录是否存在的显式检查和错误提示，在缺失时及时报告。
- 在虚拟环境创建或激活失败，以及依赖安装失败时立即停止执行，以改进失败处理逻辑。
- 当主 AstrBot 进程以错误状态退出时进行报告，而不是静默继续执行。

**改进与增强：**
- 强化启动器中的 PowerShell 使用方式，在网络操作中使用 `Invoke-RestMethod`，并采用更严格的错误处理及 no-profile 模式。
- 改进启动脚本中虚拟环境创建和依赖安装过程的日志记录与诊断信息。

**文档：**
- 在 README 中记录推荐的通过官方 AstrBot Release 安装的路径，并更正启动脚本名称以及调整 Python 命令的相关说明。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

提升 Windows 启动脚本在环境校验、发布版本下载、依赖安装以及进程退出状态上报方面的健壮性，并在 README 中澄清推荐的安装路径。

新功能：
- 为 pip、uv 和 requirements 安装失败的情况添加自动回退机制：从镜像 PyPI 索引自动回退到官方 PyPI 索引。

错误修复：
- 确保在获取 GitHub Release 时会校验 API 响应和下载 URL，并在 API、下载或解压出错时快速失败并给出清晰的错误信息。
- 通过使用子例程返回码和显式的 errorlevel 检查，防止在下载失败后启动器继续执行。
- 在设置前检测 AstrBot 或 QQChannelChatGPT 目录是否缺失，如缺失则中止并给出明确的错误提示。
- 在虚拟环境创建、激活或依赖安装失败时停止执行，而不是静默继续。
- 在主 AstrBot 进程返回非零退出码时进行报告，而不是静默退出。

增强：
- 通过在启动器中使用带 no-profile 的 PowerShell `Invoke-RestMethod` 以及更严格的网络错误处理，加强 PowerShell 的使用安全性。
- 改进虚拟环境设置和依赖安装步骤中的日志记录与诊断信息。
- 跟踪并向调用方传递统一的启动器退出码，以便于更清晰的外部错误处理。

文档：
- 在 README 中记录通过官方 AstrBot Release 进行安装的推荐方式，并更正启动脚本名称和 Python 命令的使用说明。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 总结

改进 Windows 启动脚本在环境检查、版本发布下载、依赖安装和退出码方面的健壮性，并在 README 中澄清推荐的安装步骤。

新特性：
- 为 pip、uv 和 requirements 安装失败时，新增从镜像 PyPI 索引自动回退到官方 PyPI 索引的机制。

缺陷修复：
- 当缺少 Python 或 Python 版本低于要求时停止启动器运行，并返回明确的非零退出码。
- 当 GitHub 发布版本元数据获取、下载链接获取、文件下载或压缩包解压失败时快速失败，并给出清晰的错误信息。
- 通过显式检查 AstrBot 或 QQChannelChatGPT 目录是否存在，防止在这些目录缺失时继续执行安装。
- 在虚拟环境创建或激活失败，以及依赖安装出错时中止执行，而不是静默继续。
- 当主 AstrBot 进程返回非零退出码时进行上报，而不是静默退出。

增强改进：
- 通过使用无配置文件模式（no-profile）、`Invoke-RestMethod`，以及对网络和压缩包操作采用更严格的错误处理方式，加强启动器中对 PowerShell 的使用安全性。
- 改进虚拟环境和依赖安装过程的日志记录，并统一跟踪和返回单一的启动器退出码。
- 在保持错误场景下可配置的暂停行为的同时，避免在运行成功时暂停。

文档：
- 在 README 中记录通过官方 AstrBot Releases 的推荐安装路径，并修正启动脚本名称以及 PowerShell/Python 的使用说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

增强 Windows 启动脚本在环境检查、发布版本下载、依赖安装以及退出码报告方面的健壮性，并更新 README，使其中的安装说明和脚本名称更加清晰、且与当前情况保持一致。

New Features:
- 当 `pip`、`uv` 或安装 `requirements` 失败时，自动从镜像 PyPI 索引回退到官方 PyPI 索引。

Bug Fixes:
- 当未安装 Python 或 Python 版本低于要求时，以清晰的非零退出码停止启动器。
- 确保 GitHub 发布元数据获取、下载 URL 获取、文件下载以及归档解压失败时，会立即终止并给出清晰的错误信息，而不是继续执行。
- 当缺少 `AstrBot` 或 `QQChannelChatGPT` 目录，或虚拟环境创建、激活、依赖安装失败时，中止安装流程并给出明确错误。
- 当主 `AstrBot` 进程异常退出时，报告并向外传播非零退出码，而不是静默地视为成功。

Enhancements:
- 通过使用无配置文件模式（no-profile）、`Invoke-RestMethod`、更严格的错误处理以及发布版本下载重试逻辑，改进启动器中的 PowerShell 使用。
- 优化虚拟环境和依赖安装的日志与诊断信息，并在外部错误处理时一致地向外传播单一的启动器退出码。
- 在运行成功时避免暂停，同时保留在出错时可配置的暂停行为。

Documentation:
- 在 README 中记录通过官方 AstrBot 发布版本进行安装的推荐路径，并更正 Windows 启动脚本名称以及有关 Python/PowerShell 使用的说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen the Windows launcher script’s robustness around environment checks, release download, dependency installation, and exit-code reporting, and refresh the README with clearer, up-to-date installation instructions and script names.

New Features:
- Add automatic fallback from the mirror PyPI index to the official PyPI index when pip, uv, or requirements installation fails.

Bug Fixes:
- Stop the launcher with a clear non-zero exit code when Python is missing or below the required version.
- Ensure GitHub release metadata, download URL retrieval, file download, and archive extraction failures cause immediate, clearly messaged termination instead of continuing execution.
- Abort setup with explicit errors when the AstrBot or QQChannelChatGPT directory is missing, or when virtual environment creation, activation, or dependency installation fails.
- Report and propagate a non-zero exit code when the main AstrBot process exits abnormally instead of silently succeeding.

Enhancements:
- Improve PowerShell usage in the launcher by using no-profile mode, Invoke-RestMethod, stricter error handling, and retry logic for release downloads.
- Refine virtual environment and dependency installation logging and diagnostics, and consistently propagate a single launcher exit code for clearer external error handling.
- Avoid pausing on successful runs while retaining configurable pause behavior on errors.

Documentation:
- Document the recommended installation path via official AstrBot releases and correct the Windows launcher script name and Python/PowerShell usage notes in the README.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

增强 Windows 启动脚本在环境检查、发布版本下载、依赖安装以及退出码报告方面的健壮性，并更新 README，使其中的安装说明和脚本名称更加清晰、且与当前情况保持一致。

New Features:
- 当 `pip`、`uv` 或安装 `requirements` 失败时，自动从镜像 PyPI 索引回退到官方 PyPI 索引。

Bug Fixes:
- 当未安装 Python 或 Python 版本低于要求时，以清晰的非零退出码停止启动器。
- 确保 GitHub 发布元数据获取、下载 URL 获取、文件下载以及归档解压失败时，会立即终止并给出清晰的错误信息，而不是继续执行。
- 当缺少 `AstrBot` 或 `QQChannelChatGPT` 目录，或虚拟环境创建、激活、依赖安装失败时，中止安装流程并给出明确错误。
- 当主 `AstrBot` 进程异常退出时，报告并向外传播非零退出码，而不是静默地视为成功。

Enhancements:
- 通过使用无配置文件模式（no-profile）、`Invoke-RestMethod`、更严格的错误处理以及发布版本下载重试逻辑，改进启动器中的 PowerShell 使用。
- 优化虚拟环境和依赖安装的日志与诊断信息，并在外部错误处理时一致地向外传播单一的启动器退出码。
- 在运行成功时避免暂停，同时保留在出错时可配置的暂停行为。

Documentation:
- 在 README 中记录通过官方 AstrBot 发布版本进行安装的推荐路径，并更正 Windows 启动脚本名称以及有关 Python/PowerShell 使用的说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen the Windows launcher script’s robustness around environment checks, release download, dependency installation, and exit-code reporting, and refresh the README with clearer, up-to-date installation instructions and script names.

New Features:
- Add automatic fallback from the mirror PyPI index to the official PyPI index when pip, uv, or requirements installation fails.

Bug Fixes:
- Stop the launcher with a clear non-zero exit code when Python is missing or below the required version.
- Ensure GitHub release metadata, download URL retrieval, file download, and archive extraction failures cause immediate, clearly messaged termination instead of continuing execution.
- Abort setup with explicit errors when the AstrBot or QQChannelChatGPT directory is missing, or when virtual environment creation, activation, or dependency installation fails.
- Report and propagate a non-zero exit code when the main AstrBot process exits abnormally instead of silently succeeding.

Enhancements:
- Improve PowerShell usage in the launcher by using no-profile mode, Invoke-RestMethod, stricter error handling, and retry logic for release downloads.
- Refine virtual environment and dependency installation logging and diagnostics, and consistently propagate a single launcher exit code for clearer external error handling.
- Avoid pausing on successful runs while retaining configurable pause behavior on errors.

Documentation:
- Document the recommended installation path via official AstrBot releases and correct the Windows launcher script name and Python/PowerShell usage notes in the README.

</details>

</details>

</details>

</details>

</details>